### PR TITLE
Minor typos

### DIFF
--- a/src/content/chapter0_basics/lesson01_hello_world/text.html
+++ b/src/content/chapter0_basics/lesson01_hello_world/text.html
@@ -8,7 +8,7 @@
   module, which is part of the Gleam standard library.
 </p>
 <p>
-  In a normal Gleam program this program would be run use the command
+  In a normal Gleam program this program would be run using the command
   <code>gleam run</code> on the command line, but here in this tour the program
   is automatically compiled and run as the code is edited.
 </p>

--- a/src/content/chapter0_basics/lesson12_type_aliases/text.html
+++ b/src/content/chapter0_basics/lesson12_type_aliases/text.html
@@ -4,5 +4,5 @@
 </p>
 <p>
   When the <code>pub</code> keyword is used the type alias is public and can be
-  referred to by other module.
+  referred to by other modules.
 </p>


### PR DESCRIPTION
Minor typos:

https://tour.gleam.run/basics/hello-world/
`this program would be run use the command` use -> using

https://tour.gleam.run/basics/type-aliases/
`and can be referred to by other module.` module -> modules