### PR TITLE
basics/strings/ edits

### DIFF
--- a/src/content/chapter0_basics/lesson07_strings/code.gleam
+++ b/src/content/chapter0_basics/lesson07_strings/code.gleam
@@ -11,6 +11,9 @@ pub fn main() {
   )
   io.debug("\u{1F600}")
 
+  // Use io.println to see an escape sequence in action
+  io.println("\"X\" marks the spot")
+
   // String concatenation
   io.debug("One " <> "Two")
 

--- a/src/content/chapter0_basics/lesson07_strings/text.html
+++ b/src/content/chapter0_basics/lesson07_strings/text.html
@@ -1,5 +1,5 @@
 <p>
-  In Gleam Strings are written as text surrounded by double quotes, and
+  In Gleam strings are written as text surrounded by double quotes, and
   can span multiple lines and contain unicode characters.
 </p>
 <p>


### PR DESCRIPTION
Two small suggestions for https://tour.gleam.run/basics/strings/:
1. `In Gleam Strings are written`
"Strings" is lowercase below. Should it be lowercase here?
2. There isn't an example with an escape string, and it's a little confusing because if you add one inside an `io.debug` call it shows the backslash and all. I added an `io.println` call with an escape string and a comment for clarity.
