### PR TITLE
Fix race condition in webworker logic (hopefully)

### DIFF
--- a/static/worker.js
+++ b/static/worker.js
@@ -65,3 +65,5 @@ self.onmessage = async (event) => {
   const result = compileEval(event.data);
   postMessage(await result);
 };
+
+postMessage({initialReadyMessage: true});


### PR DESCRIPTION
Aims to fix issue #17.

Makes use of existing variable `workerWorking` to keep track of when worker is busy.
This starts off `true`, because the worker script takes a while to register it's own `onmessage` event handler (it has to wait for the gleam compiler to be available).
When the worker is ready, it sends a message with `initialReadyMessage: true`. If the worker hasn't yet compiled the initial code, this will cause it to do so.

**Little Caveat:** This version of the code relies on the editor's `onUpdate` event listener to send the initial message to the worker. If this turns out not to be reliable (see big caveat below), we can reinstate the line at the end which manually sends the first message.

**Big Caveat:** This code has so far only been tested using devtools. Having devtools open _does_ change the behaviour of the original code (it reliably caused the otherwise-intermittent issue), so it may equally change the behaviour of this version of the code too. Ideally I would want to test it once the project has been built properly with `gleam run`, served to localhost, and probably with some network delay or whatever too. **That's why this PR is a draft at the moment.**

I've not got a working install of node on my machine (this is a `target: javascript` project), so testing this change may take me a little while, sorry.
