### PR TITLE
Explain runtime differences for floats (fixes #20)

### DIFF
--- a/src/content/chapter0_basics/lesson05_floats/code.gleam
+++ b/src/content/chapter0_basics/lesson05_floats/code.gleam
@@ -18,6 +18,9 @@ pub fn main() {
   io.debug(1.1 == 1.1)
   io.debug(2.1 == 1.2)
 
+  // Division by zero is not an error
+  io.debug(3.14 /. 0.0)
+
   // Standard library float functions
   io.debug(float.max(2.0, 9.5))
   io.debug(float.ceiling(5.4))

--- a/src/content/chapter0_basics/lesson05_floats/text.html
+++ b/src/content/chapter0_basics/lesson05_floats/text.html
@@ -1,15 +1,27 @@
 <p>Gleam's <code>Float</code> type represents numbers that are not integers.</p>
 <p>
-  Unlike many languages Gleam does not have a <code>NaN</code> or
-  <code>Infinity</code> float value.
-</p>
-<p>
-  Gleam's numerical operators are not overloaded, so there are dedictated
+  Gleam's numerical operators are not overloaded, so there are dedicatated
   operators for working with floats.
 </p>
 <p>
-  Floats are represented as 64 bit floating point numbers on both Erlang and
-  JavaScript runtimes.
+  Floats are represented as 64 bit floating point numbers on both the Erlang and
+  JavaScript runtimes. The floating point behaviour is native to their
+  respective runtimes, so their exact behaviour will be slightly different
+  on the two runtimes.
+</p>
+<p>
+  Under the JavaScript runtime, exceeding the maximum (or minimum) representable
+  value for a floating point value will result in <code>Infinity</code> (or
+  <code>-Infinity</code>). Should you try to divide two infinities you will
+  get <code>NaN</code> as a result.
+</p>
+<p>
+  When running on the BEAM any overflow will raise an error. So there is
+  no <code>NaN</code> or <code>Infinity</code> float value in the Erlang
+  runtime.
+</p>
+<p>
+  Division by zero will not overflow, but is instead defined to be zero.
 </p>
 <p>
   The


### PR DESCRIPTION
The differences between the runtimes was unexpected for me, so I think it would be good to mention it in the language tour.

this might be too detailed information to be in the `basics` chapter. feel free to throw the suggestions away, or rewrite it however you like. this is the information I was looking for regarding floats at least.

closes #20 