### PR TITLE
Fix "dedicated" typo in Chapter 0

### DIFF
--- a/src/content/chapter0_basics/lesson05_floats/text.html
+++ b/src/content/chapter0_basics/lesson05_floats/text.html
@@ -1,6 +1,6 @@
 <p>Gleam's <code>Float</code> type represents numbers that are not integers.</p>
 <p>
-  Gleam's numerical operators are not overloaded, so there are dedicatated
+  Gleam's numerical operators are not overloaded, so there are dedicated
   operators for working with floats.
 </p>
 <p>


### PR DESCRIPTION
A small typo on `dedicated` I found while going through the language tour.