### PR TITLE
changed description of underscore in function capture syntax

### DIFF
--- a/src/content/chapter1_functions/lesson05_function_captures/en.html
+++ b/src/content/chapter1_functions/lesson05_function_captures/en.html
@@ -7,5 +7,6 @@
   The anonymous function <code>fn(a) { some_function(..., a, ...) }</code> can
   be written as <code>some_function(..., _, ...)</code>, with any number of
   other arguments passed to the inner function. The underscore <code>_</code> is
-  a placeholder for the final argument.
+  a placeholder for the argument, equivalent to <code>a</code> in 
+  <code>fn(a) { some_function(..., a, ...) }</code>.
 </p>


### PR DESCRIPTION
It didn't make sense to me to call it the "final argument".