### PR TITLE
Add homepage link in the navbar

### DIFF
--- a/src/tour.gleam
+++ b/src/tour.gleam
@@ -572,6 +572,7 @@ fn lesson_html(page: Lesson) -> String {
           text("Gleam Language Tour"),
         ]),
         h("div", [#("class", "nav-right")], [
+          h("a", [#("href", "https://gleam.run")], [text("Homepage")]),
           h("div", [#("class", "theme-picker")], [
             h(
               "button",

--- a/static/style.css
+++ b/static/style.css
@@ -130,6 +130,12 @@ a code {
   color: var(--color-navbar-link);
 }
 
+.navbar .nav-right {
+  display: flex;
+  align-items: center;
+  gap: 1em;
+}
+
 html.theme-dark .theme-button.-dark {
   display: none;
 }


### PR DESCRIPTION
I have noticed there is no way to return to the homepage from the tour besides manually changing the URL. After people familiarize themselves with Gleam, the link to the homepage will be a call to action to continue using Gleam :)

<img width="1680" alt="image" src="https://github.com/gleam-lang/language-tour/assets/51953549/6840eda6-5016-4602-b98b-01643b59c68a">

Note – on small viewports (<360px), the navbar begins to break. This is mainly due to fixed `height`, but fixes to that require much more effort, since page layout depends on the navbar height. 