### PR TITLE
Update pattern aliases en.html to match the code example

### DIFF
--- a/src/content/chapter2_flow_control/lesson10_pattern_aliases/en.html
+++ b/src/content/chapter2_flow_control/lesson10_pattern_aliases/en.html
@@ -2,6 +2,6 @@
   The <code>as</code> operator can be used to assign sub patterns to variables.
 </p>
 <p>
-  The pattern <code>[_, ..] as it</code> will match any non-empty list and
-  assign that list to the variable <code>it</code>.
+  The pattern <code>[_, ..] as first</code> will match any non-empty list and
+  assign that list to the variable <code>first</code>.
 </p>


### PR DESCRIPTION
I personally think that it would be better if the description matches the code snippet, at least it works better for me.