### PR TITLE
Fix typo in Basics - Ints

### DIFF
--- a/src/content/chapter0_basics/lesson04_ints/en.html
+++ b/src/content/chapter0_basics/lesson04_ints/en.html
@@ -6,7 +6,7 @@
 <p>
   When running on the Erlang virtual machine ints have no maximum and minimum
   size. When running on JavaScript runtimes ints are represented using
-  JavaScript's 64 bit floating point numbers,
+  JavaScript's 64 bit floating point numbers.
 </p>
 <p>
   The


### PR DESCRIPTION
Replace ',' with '.' at end of sentence