### PR TITLE
Revert "fix nav-bar on MS Edge"

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -92,20 +92,6 @@ h6 {
   font-weight: normal;
 }
 
-nav {
-  position: fixed;
-  /*
-  `fixed` collapses `.navbar`
-  (probably related to `display: flex`),
-  thus the need for this:
-  */
-  width: 100%; /* not `vw`,
-  because it will overflow within a container
-  (except `body`)
-  */
-  z-index: 1;
-}
-
 .navbar {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
Reverts gleam-lang/language-tour#64

Sorry @Rudxain, I've have to revert this as it makes the navbar stick to the top of the screen rather than the page, and it breaks the positioning of the navigations links.