### PR TITLE
Code snippets design tweaks

### DIFF
--- a/static/common.css
+++ b/static/common.css
@@ -18,6 +18,7 @@
   --menthol: #c8ffa7;
   --caramel: #ffd596;
   --deep-saffron: #ff9d35;
+  --deep-sea-blue: #202431;
   --tomato: #ff6262;
 
   /* Semantic colors */
@@ -34,7 +35,7 @@
 
   /* Dark theme */
   --dark-theme-background: var(--underwater-blue);
-  --dark-theme-background-dim: var(--black);
+  --dark-theme-background-dim: var(--deep-sea-blue);
   --dark-theme-text: var(--white);
   --dark-theme-text-secondary: var(--aged-plastic-yellow);
   --dark-theme-code: var(--deep-saffron);

--- a/static/common.css
+++ b/static/common.css
@@ -18,7 +18,6 @@
   --menthol: #c8ffa7;
   --caramel: #ffd596;
   --deep-saffron: #ff9d35;
-  --deep-sea-blue: #202431;
   --tomato: #ff6262;
 
   /* Semantic colors */
@@ -35,7 +34,7 @@
 
   /* Dark theme */
   --dark-theme-background: var(--underwater-blue);
-  --dark-theme-background-dim: var(--deep-sea-blue);
+  --dark-theme-background-dim: var(--black);
   --dark-theme-text: var(--white);
   --dark-theme-text-secondary: var(--aged-plastic-yellow);
   --dark-theme-code: var(--deep-saffron);

--- a/static/css/pages/everything.css
+++ b/static/css/pages/everything.css
@@ -161,6 +161,7 @@ h3 {
   position: relative;
   background: var(--code-background);
   box-shadow: var(--drop-shadow);
+  border-radius: .25rem;
 }
 
 #everything-lessons .lesson-snippet code {
@@ -184,7 +185,7 @@ h3 {
   gap: var(--gap);
   font-size: var(--font-size-small);
   color: var(--color-link);
-  border-radius: none;
+  border-radius: .25rem 0 .25rem 0;
   text-decoration: none;
   outline: 1px solid transparent;
   outline-offset: -1px;


### PR DESCRIPTION
I am putting forward a suggestion to the code blocks, making them rounded and have a softer drop shadow I feel fits the branding more, with the rounded points on Lucy and the general soft colour pallet.

![image](https://github.com/gleam-lang/language-tour/assets/43214378/d1bebb2b-a4ed-41b3-bab9-ce4711b35dd3)

_Note: the colour change for the code snippet brackets icon must be from another commit_
