### PR TITLE
Put nav at the bottom of the page, so it doesn't move around from lesson to lesson.

### DIFF
--- a/src/tour.gleam
+++ b/src/tour.gleam
@@ -617,17 +617,20 @@ fn lesson_page_render(lesson: Lesson) -> String {
     static_content: [render_navbar()],
     content: [
       h("article", [#("id", "playground")], [
-        h("section", [#("id", "left")], [
-          h("h2", [], [text(lesson.name)]),
-          htmb.dangerous_unescaped_fragment(string_builder.from_string(
-            lesson.text,
-          )),
-          h("nav", [#("class", "prev-next")], [
-            navlink("Back", lesson.previous),
-            text(" — "),
-            h("a", [#("href", path_table_of_contents)], [text("Contents")]),
-            text(" — "),
-            navlink("Next", lesson.next),
+        h("section", [#("id", "left"), #("class", "content-nav")], [
+          h("div", [], [
+            h("h2", [], [text(lesson.name)]),
+            htmb.dangerous_unescaped_fragment(string_builder.from_string(
+              lesson.text,
+            )),
+          ]),
+            h("nav", [#("class", "prev-next")], [
+              navlink("Back", lesson.previous),
+              text(" — "),
+              h("a", [#("href", path_table_of_contents)], [text("Contents")]),
+              text(" — "),
+              navlink("Next", lesson.next),
+            ]),
           ]),
         ]),
         h("section", [#("id", "right")], [
@@ -636,7 +639,6 @@ fn lesson_page_render(lesson: Lesson) -> String {
           ]),
           h("aside", [#("id", "output")], []),
         ]),
-      ]),
     ],
     scripts: ScriptConfig(
       body: [

--- a/src/tour.gleam
+++ b/src/tour.gleam
@@ -624,21 +624,21 @@ fn lesson_page_render(lesson: Lesson) -> String {
               lesson.text,
             )),
           ]),
-            h("nav", [#("class", "prev-next")], [
-              navlink("Back", lesson.previous),
-              text(" — "),
-              h("a", [#("href", path_table_of_contents)], [text("Contents")]),
-              text(" — "),
-              navlink("Next", lesson.next),
-            ]),
+          h("nav", [#("class", "prev-next")], [
+            navlink("Back", lesson.previous),
+            text(" — "),
+            h("a", [#("href", path_table_of_contents)], [text("Contents")]),
+            text(" — "),
+            navlink("Next", lesson.next),
           ]),
         ]),
-        h("section", [#("id", "right")], [
-          h("section", [#("id", "editor")], [
-            h("div", [#("id", "editor-target")], []),
-          ]),
-          h("aside", [#("id", "output")], []),
+      ]),
+      h("section", [#("id", "right")], [
+        h("section", [#("id", "editor")], [
+          h("div", [#("id", "editor-target")], []),
         ]),
+        h("aside", [#("id", "output")], []),
+      ]),
     ],
     scripts: ScriptConfig(
       body: [

--- a/static/css/pages/lesson.css
+++ b/static/css/pages/lesson.css
@@ -93,3 +93,9 @@
 .mb-0 {
   margin-bottom: 0;
 }
+
+.content-nav {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}


### PR DESCRIPTION
This is a personal preference, but I prefer when the navigation doesn't move around between lessons so I can speedily navigate back and forth multiple lessons at a time.

At the moment, you have to reposition the cursor almost every time.

![image](https://github.com/gleam-lang/language-tour/assets/8368500/39f455d2-c382-4967-9cf9-2c366a6446b2)