### PR TITLE
[Suggestion] Rewrite of tour layout and now using the "code block" style in "large" view

### DIFF
--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -7,4 +7,5 @@
   --gap-quarter: calc(0.25 * var(--gap));
 
   --navbar-height: calc(var(--gap-double) + 20px);
+  --border-radius: .25rem;
 }

--- a/static/css/pages/lesson.css
+++ b/static/css/pages/lesson.css
@@ -1,54 +1,7 @@
-#left,
-#output,
-#editor {
-  min-height: 200px;
-  overflow-y: auto;
-  border-bottom: 2px solid var(--color-divider);
-  margin: 0;
-  overflow-wrap: break-word;
-}
-
-#left> :first-child {
-  margin-top: 0;
-}
-
-#editor {
-  position: relative;
-}
-
-@media (min-width: 600px) {
-  #playground {
-    position: fixed;
-    top: var(--navbar-height);
-    bottom: 0;
-    left: 0;
-    right: 0;
-    padding-top: 0;
-  }
-
-  #left,
-  #right {
-    width: 50vw;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-  }
-
-  #left {
-    border-right: 2px solid var(--color-divider);
-  }
-
-  #right {
-    right: 0;
-  }
-
-  #right> :first-child {
-    height: 62%;
-  }
-
-  #right> :last-child {
-    height: 38%;
-  }
+#playground {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
 }
 
 #left,
@@ -57,17 +10,88 @@
   padding: var(--gap);
 }
 
+#right {
+  display: flex;
+  flex-direction: column;
+  border: var(--color-divider);
+  background: var(--code-background);
+  padding-top: .15rem;
+  overflow: hidden;
+  flex-grow: 1;
+  min-height: fit-content;
+}
+
+#output,
+#editor {
+  border-top: 1px solid var(--color-accent-muted);
+}
+
+#editor {
+  position: relative;
+  overflow: clip;
+  min-height: 14rem;
+  flex-grow: 1;
+}
+
+#output {
+  min-height: 1rem;
+  background: var(--color-background-dim);
+}
+
 #output>* {
   margin: 0;
   white-space: pre-wrap;
 }
 
+/* Larger then mobile */
+@media (min-width: 768px) {
+  #playground {
+    min-height: calc(100vh - var(--navbar-height));
+    flex-direction: row;
+  }
+
+  #left {
+    height: 100%;
+    width: 50%;
+  }
+
+  #right {
+    border-left: 1px solid var(--color-accent-muted);
+    width: 50%;
+  }
+
+  #editor {
+    border: none;
+  }
+
+  #output {
+    height: 33%;
+    overflow: auto;
+    border-top: 1px solid var(--color-accent-muted);
+  }
+}
+
+/* Larger than medium screen and has enough to height to not worry about losing vertical space */
+@media (min-width: 1200px) and (min-height: 700px) {
+  #left {
+    /* Lift the navigation bar up a bit so it's not sitting right on the bottom*/
+    padding-bottom: calc(var(--gap) * 2);
+  }
+
+  #right {
+    border-left: unset;
+    border-radius: var(--border-radius);
+    padding: 2px 1px;
+    box-shadow: var(--drop-shadow);
+    /* Use calc here to add additional padding dynamically to allow for the drop shadow */
+    margin: calc(var(--gap) * 2);
+  }
+}
+
 .error,
 .warning {
-  border-width: var(--gap);
   border-style: solid;
-  border-top: 0;
-  border-bottom: 0;
+  height: 100%;
 }
 
 .error {

--- a/static/css/pages/lesson.css
+++ b/static/css/pages/lesson.css
@@ -29,7 +29,6 @@
 #editor {
   position: relative;
   overflow: clip;
-  min-height: 14rem;
   flex-grow: 1;
 }
 
@@ -46,13 +45,18 @@
 /* Larger then mobile */
 @media (min-width: 768px) {
   #playground {
-    min-height: calc(100vh - var(--navbar-height));
+    min-height: calc(100dvh - var(--navbar-height));
     flex-direction: row;
   }
 
   #left {
     height: 100%;
     width: 50%;
+    overflow-y: auto;
+
+    & h2:first-of-type {
+      margin-top: 0;
+    }
   }
 
   #right {
@@ -75,7 +79,7 @@
 @media (min-width: 1200px) and (min-height: 700px) {
   #left {
     /* Lift the navigation bar up a bit so it's not sitting right on the bottom*/
-    padding-bottom: calc(var(--gap) * 2);
+    padding: calc(var(--gap) * 2);
   }
 
   #right {
@@ -84,7 +88,10 @@
     padding: 2px 1px;
     box-shadow: var(--drop-shadow);
     /* Use calc here to add additional padding dynamically to allow for the drop shadow */
-    margin: calc(var(--gap) * 2);
+    margin-top: calc(var(--gap) * 2);
+    margin-right: calc(var(--gap) * 3);
+    margin-bottom: calc(var(--gap) * 3);
+    margin-left: calc(var(--gap) * 2);
   }
 }
 


### PR DESCRIPTION
In line with the "everything" page using the code blocks I thought I was playing around with what this would look like using this theme in the "tour" page. I think it looks quite nice

I have three states: mobile (first), small screen, full screen ("large").  In "mobile" and "small screen" the appearance will be almost identical to the curren view.

I large view I apply the code block styling and add some padding to bring it away from the edge of the screen. 

### Mobile:

![image](https://github.com/gleam-lang/language-tour/assets/43214378/b6eb8e8a-3fce-45c4-a407-dd4868546032)

### Small Screen: 

![image](https://github.com/gleam-lang/language-tour/assets/43214378/171837fb-37ae-4837-94d8-4be80f5d6686)

### Large Screen:

![image](https://github.com/gleam-lang/language-tour/assets/43214378/09eeef8a-94e8-46e0-bca4-5d41f7f38e8e)


_Note: While doing this, I have changed to using flex box to allow us more layout flexibility in the future rather than using absolute positioning_
