### PR TITLE
Add hrefs to code keywords

### DIFF
--- a/src/content/chapter0_basics/lesson02_modules/en.html
+++ b/src/content/chapter0_basics/lesson02_modules/en.html
@@ -1,22 +1,37 @@
 <p>
   Gleam code is organized into units called <em>modules</em>. A module is a
   bunch of definitions (of types, functions, etc.) that seem to belong together.
-  For example, the <code>gleam/io</code> module contains a variety of functions
-  for printing, like <code>println</code>.
+  For example, the 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/io.html" target="_blank">
+    <code>gleam/io</code>
+  </a> 
+  module contains a variety of functions for printing, like 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/io.html#println" target="_blank">
+    <code>println</code>
+  </a>.
 </p>
 <p>
   All gleam code is in <i>some</i> module or other, whose name comes from the
-  name of the file it's in. For example, <code>gleam/io</code> is in a file
-  called <code>io.gleam</code> in a directory called <code>gleam</code>.
+  name of the file it's in. For example, 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/io.html" target="_blank">
+    <code>gleam/io</code>
+  </a> 
+  is in a file called <code>io.gleam</code> in a directory called <code>gleam</code>.
 </p>
 <p>
   For code in one module to access code in another module, we import it using
   the <code>import</code> keyword, and the name used to refer to it is the last
-  part of the module name. For example, the <code>gleam/io</code> module is
-  referred to as <code>io</code> once imported.
+  part of the module name. For example, the 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/io.html" target="_blank">
+    <code>gleam/io</code>
+  </a> 
+  module is referred to as <code>io</code> once imported.
 </p>
 <p>
   The <code>as</code> keyword can be used to refer to a module by a different
-  name. See how the <code>gleam/string</code> module is referred to as
-  <code>text</code> here.
+  name. See how the 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/string.html" target="_blank">
+    <code>gleam/string</code>
+  </a> 
+  module is referred to as <code>text</code> here.
 </p>

--- a/src/content/chapter0_basics/lesson03_unqualified_imports/en.html
+++ b/src/content/chapter0_basics/lesson03_unqualified_imports/en.html
@@ -2,7 +2,9 @@
   Normally functions from other modules are used in a
   <em>qualified</em> fashion, meaning the name used to refer the module goes
   before function name with a dot between them. For example,
-  <code>io.println("Hello!")</code>.
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/io.html#println" target="_blank">
+    <code>io.println("Hello!")</code>
+  </a>.
 </p>
 <p>
   It is also possible to specify a list of functions to import from a module in

--- a/src/content/chapter0_basics/lesson04_type_checking/en.html
+++ b/src/content/chapter0_basics/lesson04_type_checking/en.html
@@ -3,12 +3,22 @@
   code, catching mistakes and showing you where to make changes.
 </p>
 <p>
-  Uncomment the line <code>io.println(4)</code> and see how a compile time error
-  is reported as the <code>io.println</code> function only works with strings,
-  not ints.
+  Uncomment the line 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/io.html#println" target="_blank">
+    <code>io.println(4)</code>
+  </a> 
+  and see how a compile time error
+  is reported as the 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/io.html#println" target="_blank">
+    <code>io.println</code>
+  </a> 
+  function only works with strings, not ints.
 </p>
 <p>
-  To fix the code change the code to call the <code>io.debug</code>
+  To fix the code change the code to call the 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/io.html#debug" target="_blank">
+    <code>io.debug</code>
+  </a> 
   function instead, as it will print a value of any type.
 </p>
 <p>

--- a/src/content/chapter0_basics/lesson05_ints/en.html
+++ b/src/content/chapter0_basics/lesson05_ints/en.html
@@ -9,9 +9,9 @@
   JavaScript's 64 bit floating point numbers,
 </p>
 <p>
-  The
-  <a href="https://hexdocs.pm/gleam_stdlib/gleam/int.html"
-    ><code>gleam/int</code></a
-  >
+  The 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/int.html" target="_blank">
+    <code>gleam/int</code>
+  </a>
   standard library module contains functions for working with ints.
 </p>

--- a/src/content/chapter0_basics/lesson06_floats/en.html
+++ b/src/content/chapter0_basics/lesson06_floats/en.html
@@ -24,9 +24,9 @@
   Division by zero will not overflow, but is instead defined to be zero.
 </p>
 <p>
-  The
-  <a href="https://hexdocs.pm/gleam_stdlib/gleam/float.html"
-    ><code>gleam/float</code></a
-  >
+  The 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/float.html" target="_blank">
+    <code>gleam/float</code>
+  </a> 
   standard library module contains functions for working with floats.
 </p>

--- a/src/content/chapter0_basics/lesson09_strings/en.html
+++ b/src/content/chapter0_basics/lesson09_strings/en.html
@@ -18,6 +18,9 @@
   <li><code>\u{xxxxxx}</code> - unicode codepoint</li>
 </ul>
 <p>
-  The <a href="https://hexdocs.pm/gleam_stdlib/gleam/string.html"><code>gleam/string</code></a>
+  The 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/string.html" target="_blank">
+    <code>gleam/string</code>
+  </a> 
   standard library module contains functions for working with strings.
 </p>

--- a/src/content/chapter0_basics/lesson10_bools/en.html
+++ b/src/content/chapter0_basics/lesson10_bools/en.html
@@ -12,6 +12,9 @@
   side of the operator will not be evaluated.
 </p>
 <p>
-  The <a href="https://hexdocs.pm/gleam_stdlib/gleam/bool.html"><code>gleam/bool</code></a>
+  The 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/bool.html" target="_blank">
+    <code>gleam/bool</code>
+  </a> 
   standard library module contains functions for working with bools.
 </p>

--- a/src/content/chapter0_basics/lesson14_type_imports/en.html
+++ b/src/content/chapter0_basics/lesson14_type_imports/en.html
@@ -4,8 +4,10 @@
 </p>
 <p>
   Like functions types can be referred to in a <em>qualified</em> way by putting
-  the imported module name and a dot before the type name. For example,
-  <code>bytes_builder.BytesBuilder</code>
+  the imported module name and a dot before the type name. For example, 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/bytes_builder.html#BytesBuilder" target="_blank">
+    <code>bytes_builder.BytesBuilder</code>
+  </a>
 </p>
 <p>
   Types can also be imported in an <em>unqualified</em> way by listing them in

--- a/src/content/chapter0_basics/lesson16_blocks/en.html
+++ b/src/content/chapter0_basics/lesson16_blocks/en.html
@@ -7,8 +7,11 @@
   Any variables assigned within the block can only be used within the block.
 </p>
 <p>
-  Try uncommenting <code>io.debug(degrees)</code> to see the compile error from
-  trying to use a variable that is not in scope.
+  Try uncommenting 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/io.html#debug" target="_blank">
+    <code>io.debug(degrees)</code>
+  </a> 
+  to see the compile error from trying to use a variable that is not in scope.
 </p>
 <p>
   Blocks can also be used to change the order of evaluation of binary operators

--- a/src/content/chapter0_basics/lesson17_lists/en.html
+++ b/src/content/chapter0_basics/lesson17_lists/en.html
@@ -2,9 +2,11 @@
   Lists are ordered collections of values.
 </p>
 <p>
-  <code>List</code> is a generic type, having a type parameter
-  for the type of values it contains. A list of ints has the type
-  <code>List(Int)</code>, and a list of strings has the type
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/list.html" target="_blank">
+    <code>List</code>
+  </a> 
+  is a generic type, having a type parameter for the type of values it contains. 
+  A list of ints has the type <code>List(Int)</code>, and a list of strings has the type
   <code>List(String)</code>.
 </p>
 <p>

--- a/src/content/chapter2_flow_control/lesson07_list_recursion/en.html
+++ b/src/content/chapter2_flow_control/lesson07_list_recursion/en.html
@@ -1,8 +1,8 @@
 <p>
-  While it is more common to use functions in the
-  <a href="https://hexdocs.pm/gleam_stdlib/gleam/list.html"
-    ><code>gleam/list</code></a
-  >
+  While it is more common to use functions in the 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/list.html" target="_blank">
+    <code>gleam/list</code>
+  </a> 
   module to iterate across a list, at times you may prefer to work
   with the list directly.
 </p>

--- a/src/content/chapter3_data_types/lesson05_generic_custom_types/en.html
+++ b/src/content/chapter3_data_types/lesson05_generic_custom_types/en.html
@@ -4,7 +4,9 @@
 </p>
 <p>
   Here a generic <code>Option</code> type is defined, which is used to represent
-  a value that is either present or absent. This type is quite useful! The
-  <code>gleam/option</code> module defines it so you can use it in your Gleam
-  projects.
+  a value that is either present or absent. This type is quite useful! The 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/option.html" target="_blank">
+    <code>gleam/option</code>
+  </a> 
+  module defines it so you can use it in your Gleam projects.
 </p>

--- a/src/content/chapter3_data_types/lesson07_results/en.html
+++ b/src/content/chapter3_data_types/lesson07_results/en.html
@@ -30,8 +30,10 @@
 <p>
   A result value can be handled by pattern matching with a
   <code>case</code> expression, but given how frequently results are returned
-  this can become unwieldy. Gleam code commonly uses the
-  <code>gleam/result</code> standard library module and
-  <code>use</code> expressions when working with results, both of which will be
-  covered in later chapters.
+  this can become unwieldy. Gleam code commonly uses the 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/result.html" target="_blank">
+    <code>gleam/result</code>
+  </a> 
+  standard library module and <code>use</code> expressions when working with results, 
+  both of which will be covered in later chapters.
 </p>

--- a/src/content/chapter4_standard_library/lesson00_standard_library_package/en.html
+++ b/src/content/chapter4_standard_library/lesson00_standard_library_package/en.html
@@ -4,8 +4,11 @@
   not use it if you wish, though almost all Gleam projects depend on it.
 </p>
 <p>
-  All of the modules imported so far in this guide, such as
-  <code>gleam/io</code>, are from the standard library.
+  All of the modules imported so far in this guide, such as 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/io.html" target="_blank">
+    <code>gleam/io</code>
+  </a>, 
+  are from the standard library.
 </p>
 <p>
   All of the documentation for the standard library is available on

--- a/src/content/chapter4_standard_library/lesson01_list_module/en.html
+++ b/src/content/chapter4_standard_library/lesson01_list_module/en.html
@@ -1,38 +1,38 @@
 <p>
   The
-  <a href="https://hexdocs.pm/gleam_stdlib/gleam/list.html"
-    ><code>gleam/list</code></a
-  >
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/list.html" target="_blank">
+    <code>gleam/list</code>
+  </a>
   standard library module contains functions for working with lists. A Gleam
   program will likely make heavy use of this module, the various functions
   serving as different types of loops over lists.
 </p>
 
 <p>
-  <a href="https://hexdocs.pm/gleam_stdlib/gleam/list.html#map"
-    ><code>map</code></a
-  >
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/list.html#map" target="_blank">
+    <code>map</code>
+  </a>
   makes a new list by running a function on each element in a list.
 </p>
 <p>
-  <a href="https://hexdocs.pm/gleam_stdlib/gleam/list.html#filter"
-    ><code>filter</code></a
-  >
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/list.html#filter" target="_blank">
+    <code>filter</code>
+  </a>
   makes a new list containing only the elements for which a function returns
   true.
 </p>
 <p>
-  <a href="https://hexdocs.pm/gleam_stdlib/gleam/list.html#fold"
-    ><code>fold</code></a
-  >
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/list.html#fold" target="_blank">
+    <code>fold</code>
+  </a>
   combines all the elements in a list into a single value by running a function
   left-to-right on each element, passing the result of the previous call to the
   next call.
 </p>
 <p>
-  <a href="https://hexdocs.pm/gleam_stdlib/gleam/list.html#find"
-    ><code>find</code></a
-  >
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/list.html#find" target="_blank">
+    <code>find</code>
+  </a>
   returns the first element in a list for which a function returns
   <code>True</code>.
 </p>

--- a/src/content/chapter4_standard_library/lesson02_result_module/en.html
+++ b/src/content/chapter4_standard_library/lesson02_result_module/en.html
@@ -1,25 +1,25 @@
 <p>
   The
-  <a href="https://hexdocs.pm/gleam_stdlib/gleam/result.html"
-    ><code>gleam/result</code></a
-  >
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/result.html" target="_blank">
+    <code>gleam/result</code>
+  </a>
   standard library module contains functions for working with results. Gleam
   programs will make heavy use of this module to avoid excessive nested case
   expressions when calling multiple functions that can fail.
 </p>
 
 <p>
-  <a href="https://hexdocs.pm/gleam_stdlib/gleam/result.html#map"
-    ><code>map</code></a
-  >
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/result.html#map" target="_blank">
+    <code>map</code>
+  </a>
   updates a value held within the Ok of a result by calling a given function on
   it. If the result is an error then the function is not called.
 </p>
 
 <p>
-  <a href="https://hexdocs.pm/gleam_stdlib/gleam/result.html#try"
-    ><code>try</code></a
-  >
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/result.html#try" target="_blank">
+    <code>try</code>
+  </a>
   runs a result returning function on the value held within an Ok of a result.
   If the result is an error then the function is not called. This is useful for
   chaining together multiple function calls that can fail, one after the other,
@@ -27,9 +27,9 @@
 </p>
 
 <p>
-  <a href="https://hexdocs.pm/gleam_stdlib/gleam/result.html#unwrap"
-    ><code>unwrap</code></a
-  >
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/result.html#unwrap" target="_blank">
+    <code>unwrap</code>
+  </a>
   extracts the success value from a result, or returning a default value if the
   result is an error.
 </p>

--- a/src/content/chapter4_standard_library/lesson03_dict_module/en.html
+++ b/src/content/chapter4_standard_library/lesson03_dict_module/en.html
@@ -9,24 +9,24 @@
 </p>
 
 <p>
-  <a href="https://hexdocs.pm/gleam_stdlib/gleam/dict.html#new"
-    ><code>new</code></a
-  >
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/dict.html#new" target="_blank">
+    <code>new</code>
+  </a>
   and
-  <a href="https://hexdocs.pm/gleam_stdlib/gleam/dict.html#from_list"
-    ><code>from_list</code></a
-  >
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/dict.html#from_list" target="_blank">
+    <code>from_list</code>
+  </a>
   can be used to create new dicts.
 </p>
 
 <p>
-  <a href="https://hexdocs.pm/gleam_stdlib/gleam/dict.html#insert"
-    ><code>insert</code></a
-  >
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/dict.html#insert" target="_blank">
+    <code>insert</code>
+  </a>
   and
-  <a href="https://hexdocs.pm/gleam_stdlib/gleam/dict.html#delete"
-    ><code>delete</code></a
-  >
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/dict.html#delete" target="_blank">
+    <code>delete</code>
+  </a>
   are used to add and remove items from a dict.
 </p>
 <p>

--- a/src/content/chapter4_standard_library/lesson04_option_module/en.html
+++ b/src/content/chapter4_standard_library/lesson04_option_module/en.html
@@ -1,10 +1,13 @@
 <p>
   Values in Gleam are not nullable, so the
-  <a href="https://hexdocs.pm/gleam_stdlib/gleam/option.html"
-    ><code>gleam/option</code></a
-  >
-  standard library module defines Gleam's <code>Option</code> type, which can be
-  used to represent a value that is either present or absent.
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/option.html" target="_blank">
+    <code>gleam/option</code>
+  </a>
+  standard library module defines Gleam's 
+  <a href="https://hexdocs.pm/gleam_stdlib/gleam/option.html#Option" target="_blank">
+    <code>Option</code>
+  </a> 
+  type, which can be used to represent a value that is either present or absent.
 </p>
 
 <p>

--- a/src/tour.gleam
+++ b/src/tour.gleam
@@ -56,10 +56,17 @@ const home_html = "
 </p>
 <p>
   The tour is interactive! The code shown is editable and will be compiled and
-  evaluated as you type. Anything you print using <code>io.println</code> or
-  <code>io.debug</code> will be shown in the bottom section, along with any
-  compile errors and warnings. To evaluate Gleam code the tour compiles Gleam to
-  JavaScript and runs it, all entirely within your browser window.
+  evaluated as you type. Anything you print using 
+  <a href=\"https://hexdocs.pm/gleam_stdlib/gleam/io.html#print\" target=\"_blank\">
+    <code>io.println</code>
+  </a> 
+  or 
+  <a href=\"https://hexdocs.pm/gleam_stdlib/gleam/io.html#debug\" target=\"_blank\">
+    <code>io.debug</code>
+  </a> 
+  will be shown in the bottom section, along with any compile errors and warnings. 
+  To evaluate Gleam code the tour compiles Gleam to JavaScript and runs it, 
+  all entirely within your browser window.
 </p>
 <p>
   If at any point you get stuck or have a question do not hesitate to ask in

--- a/static/css/root.css
+++ b/static/css/root.css
@@ -48,10 +48,6 @@ a {
   text-decoration-color: var(--color-link-decoration);
 }
 
-a code {
-  color: inherit;
-}
-
 /*
  * Nav bar & Nav links
  */


### PR DESCRIPTION
While doing the language tour, I caught myself a couple of times trying to tap on some keywords in order to open more detailed documentation. So I decided to go over the pages present in the language tour and, where possible, wrap the code in the href that will redirect the users to the new tab with the hexdocs.

Also, I tested a couple of variations regarding the color of keywords that are both in `code` and `a` tags, and the original code color with underline seems to be optimal, but it can be changed if I'm wrong - no strong opinion on this. 😄 