### PR TITLE
Added example to anonymous functions

### DIFF
--- a/src/content/chapter1_functions/lesson04_anonymous_functions/code.gleam
+++ b/src/content/chapter1_functions/lesson04_anonymous_functions/code.gleam
@@ -7,6 +7,11 @@ pub fn main() {
 
   // Pass an anonymous function as an argument
   io.debug(twice(1, fn(a) { a * 2 }))
+
+  let secret_number = 42
+  // This anonymous function always returns 42
+  let secret = fn() { secret_number }
+  io.debug(secret())
 }
 
 fn twice(argument: Int, my_function: fn(Int) -> Int) -> Int {

--- a/src/content/chapter1_functions/lesson04_anonymous_functions/en.html
+++ b/src/content/chapter1_functions/lesson04_anonymous_functions/en.html
@@ -1,5 +1,9 @@
 <p>
-  As well as module-level named functions, Gleam has anonymous function
-  literals, written with the <code>fn() { ... }</code> syntax.
+    As well as module-level named functions, Gleam has anonymous function
+    literals, written with the <code>fn() { ... }</code> syntax.
 </p>
 <p>Anonymous functions can be used interchangeably with named functions.</p>
+<p>
+    Anonymous functions can reference variables that were in scope when they
+    were defined, making them <em>closures</em>.
+</p>


### PR DESCRIPTION
The description for anonymous functions was missing the info provided on Exercism. Added this description and example.