### PR TITLE
Fix a coma to a dot

### DIFF
--- a/src/content/chapter3_data_types/lesson00_tuples/en.html
+++ b/src/content/chapter3_data_types/lesson00_tuples/en.html
@@ -15,6 +15,6 @@
 </p>
 <p>
   Tuples are most commonly used to return 2 or 3 values from a function. Often
-  it is clearer to use a <em>custom type</em> where a tuple could be used, We
+  it is clearer to use a <em>custom type</em> where a tuple could be used. We
   will cover custom types next.
 </p>


### PR DESCRIPTION
Could also just uncapitalize `We` or write `..could could be used and we will cover..`, I think that flows better.

Huge pull request I know.