### PR TITLE
handle js interpolation

### DIFF
--- a/src/tour.gleam
+++ b/src/tour.gleam
@@ -479,6 +479,7 @@ fn generate_stdlib_bundle(modules: List(String)) -> snag.Result(Nil) {
         code
         |> string.replace("\\", "\\\\")
         |> string.replace("`", "\\`")
+        |> string.replace("$", "\\$")
         |> string.split("\n")
         |> list.filter(fn(line) { !string.starts_with(string.trim(line), "//") })
         |> list.filter(fn(line) {


### PR DESCRIPTION
This is needed because if any of your libraries have a "${}" it is treated as an escape inside backticks which are used in the line
```
Ok(" \"gleam/" <> name <> "\": `" <> code <> "`")
```