### PR TITLE
Hyphenate compound words

### DIFF
--- a/src/content/chapter4_standard_library/lesson02_result_module/en.html
+++ b/src/content/chapter4_standard_library/lesson02_result_module/en.html
@@ -20,7 +20,7 @@
   <a href="https://hexdocs.pm/gleam_stdlib/gleam/result.html#try" target="_blank">
     <code>try</code>
   </a>
-  runs a result returning function on the value held within an Ok of a result.
+  runs a result-returning function on the value held within an Ok of a result.
   If the result is an error then the function is not called. This is useful for
   chaining together multiple function calls that can fail, one after the other,
   stopping at the first error.
@@ -36,5 +36,5 @@
 
 <p>
   Result functions are often used with pipelines to chain together multiple
-  calls to result returning functions.
+  calls to result-returning functions.
 </p>


### PR DESCRIPTION
IMO the sentences were a bit difficult to read at first because the words/phrases "result returning function" were missing hyphens.