### PR TITLE
Remove extra space after link tag

### DIFF
--- a/static/css/root.css
+++ b/static/css/root.css
@@ -45,6 +45,7 @@ h6 {
 
 a {
   color: var(--color-link);
+  display: inline-block;
   text-decoration-color: var(--color-link-decoration);
 }
 


### PR DESCRIPTION
The underlining on links continued for one extra whitespace. This patch fixes the link underlining to be solely under the link.


Before:
![image](https://github.com/user-attachments/assets/3c6485f6-a5f6-47cb-9c4b-2071d5bcfc9f)

![image](https://github.com/user-attachments/assets/3f98663f-1457-488c-b6fd-947e49e95756)



After:
![image](https://github.com/user-attachments/assets/f78bd0dc-bd1a-45d4-a33f-31fbd2cd0a5c)

![image](https://github.com/user-attachments/assets/49a19da0-4667-4e72-b005-adf98f0b7be8)


