### PR TITLE
Add example for single variant record let structuring

### DIFF
--- a/src/content/chapter3_data_types/lesson04_record_pattern_matching/code.gleam
+++ b/src/content/chapter3_data_types/lesson04_record_pattern_matching/code.gleam
@@ -5,11 +5,21 @@ pub type Fish {
   Jellyfish(name: String, jiggly: Bool)
 }
 
+pub type IceCream {
+  IceCream(flavour: String)
+}
+
 pub fn main() {
   let lucy = Starfish("Lucy", "Pink")
+  let favourite_ice_cream = IceCream("strawberry")
 
   case lucy {
     Starfish(_, favourite_color) -> io.debug(favourite_color)
     Jellyfish(name, ..) -> io.debug(name)
   }
+
+  // if the custom type has a single variant you can
+  // destructure it using `let` instead of a case expression!
+  let IceCream(flavour) = favourite_ice_cream
+  io.debug(flavour)
 }


### PR DESCRIPTION
This PR adds an example for single variant record let restructuring closing #118 