### PR TITLE
Remove bool.to_int() call

### DIFF
--- a/src/content/chapter0_basics/lesson10_bools/code.gleam
+++ b/src/content/chapter0_basics/lesson10_bools/code.gleam
@@ -10,5 +10,4 @@ pub fn main() {
 
   // Bool functions
   io.debug(bool.to_string(True))
-  io.debug(bool.to_int(False))
 }


### PR DESCRIPTION
bool.to_int() was deprecated in stdlib v0.47.0 and is no longer present in v0.52.0 . I propose it simply be removed.