### PR TITLE
`README`: "the in"->"in the"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ An interactive tour of the Gleam programming language.
 # Build the site
 gleam run
 
-# It's now all the in `public/` directory
+# It's now all in the `public/` directory
 ```


### PR DESCRIPTION
Typo introduced [here](https://github.com/gleam-lang/language-tour/commit/451f7f0b0bbd8e1e187fb00d91dc829cc7347e8a#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R16)

It could've been fixed on #91, IDK why nobody said anything about it :confused: