### PR TITLE
Introduce single-variant record custom type first

### DIFF
--- a/src/content/chapter3_data_types/lesson02_records/code.gleam
+++ b/src/content/chapter3_data_types/lesson02_records/code.gleam
@@ -1,17 +1,14 @@
 import gleam/io
 
-pub type SchoolPerson {
-  Teacher(name: String, subject: String)
-  Student(String)
+pub type Person {
+  Person(name: String, age: Int, needs_glasses: Bool)
 }
 
 pub fn main() {
-  let teacher1 = Teacher("Mr Schofield", "Physics")
-  let teacher2 = Teacher(name: "Miss Percy", subject: "Physics")
-  let student1 = Student("Koushiar")
-  let student2 = Student("Naomi")
-  let student3 = Student("Shaheer")
+  let amy = Person("Amy", 26, True)
+  let jared = Person(name: "Jared", age: 31, needs_glasses: True)
+  let tom = Person("Tom", 28, needs_glasses: False)
 
-  let school = [teacher1, teacher2, student1, student2, student3]
-  io.debug(school)
+  let friends = [amy, jared, tom]
+  io.debug(friends)
 }

--- a/src/content/chapter3_data_types/lesson02_records/en.html
+++ b/src/content/chapter3_data_types/lesson02_records/en.html
@@ -11,3 +11,7 @@
   It is common to have a custom type with one variant that holds data, this is
   the Gleam equivalent of a struct or object in other languages.
 </p>
+<p>
+  When defining custom types with one variant, the single variant is often named the
+  same as the custom type, although it doesn't have to be.
+</p>

--- a/src/content/chapter3_data_types/lesson03_record_accessors/en.html
+++ b/src/content/chapter3_data_types/lesson03_record_accessors/en.html
@@ -6,7 +6,7 @@
   The accessor syntax can always be used for fields with the same name that are
   in the same position and have the same type for all variants of the custom
   type. Other fields can only be accessed when the compiler can tell which
-  variant the value is, such after pattern matching in a `case` expression.
+  variant the value is, such after pattern matching in a <code>case</code> expression.
 </p>
 <p>
   The <code>name</code> field is in the first position and has type


### PR DESCRIPTION
Closes #139
This PR introduces records in the context of single-variant custom types first, which should hopefully resolve some confusion around them.
I wasn't completely sure how to introduce multi-variant records after that. Currently, since the next page shows an example of multi-variant records, I just leave that to explain it. But I'm not super happy about how it currently is, so I'd like others' opinions on what's best here. There are a few options:
- Add another page explaining multi-variant records
- Explain multi-variant records on the same page, and have two custom types defined in the example, one with 1 variant and one with several
- Explain about multi-variant records in the record accessor page where they are used