### PR TITLE
Link to `bytes_tree` module in `basics/type-imports`

### DIFF
--- a/src/content/chapter0_basics/lesson14_type_imports/en.html
+++ b/src/content/chapter0_basics/lesson14_type_imports/en.html
@@ -6,10 +6,10 @@
   Like functions, types can be referred to in a <em>qualified</em> way by
   putting the imported module name and a dot before the type name. For example,
   <a
-    href="https://hexdocs.pm/gleam_stdlib/gleam/bytes_builder.html#BytesBuilder"
+    href="https://hexdocs.pm/gleam_stdlib/gleam/bytes_tree.html#BytesTree"
     target="_blank"
   >
-    <code>bytes_builder.BytesBuilder</code>
+    <code>bytes_tree.BytesTree</code>
   </a>
 </p>
 <p>


### PR DESCRIPTION
Remove reference and broken link to deprecated `bytes_builder`, and mirror the code example.