### PR TITLE
Update tour version to v1.9.1

### DIFF
--- a/bin/download-compiler
+++ b/bin/download-compiler
@@ -3,7 +3,7 @@
 set -eu
 
 # Ensure you update the CI Gleam version to match this
-VERSION="v1.8.0"
+VERSION="v1.9.1"
 
 rm -fr wasm-compiler
 mkdir wasm-compiler


### PR DESCRIPTION
Currently the tour is still set to use v1.8.0 while the CI was updated to v1.9.1, this just updates it.