### PR TITLE
Update gleam version to 1.9.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           otp-version: false
           # Ensure you update the bin/download-compiler Gleam version to match this
-          gleam-version: "1.6.0"
+          gleam-version: "1.9.1"
 
       - name: Download WASM version of Gleam compiler
         run: ./bin/download-compiler
@@ -40,7 +40,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: 'public'
+          path: "public"
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           otp-version: false
           # Ensure you update the bin/download-compiler Gleam version to match this
-          gleam-version: "1.8.0"
+          gleam-version: "1.9.1"
       - run: ./bin/download-compiler
       - run: gleam deps download
       - run: gleam format --check src test

--- a/bin/download-compiler
+++ b/bin/download-compiler
@@ -3,7 +3,7 @@
 set -eu
 
 # Ensure you update the CI Gleam version to match this
-VERSION="v1.8.0"
+VERSION="v1.9.1"
 
 rm -fr wasm-compiler
 mkdir wasm-compiler


### PR DESCRIPTION
The language tour is broken at the moment: the compiler is stuck to 1.8.0 but now the tour is using echo, resulting in compilation errors!