### PR TITLE
Fix typo in record access error example

### DIFF
--- a/src/content/chapter3_data_types/lesson03_record_accessors/code.gleam
+++ b/src/content/chapter3_data_types/lesson03_record_accessors/code.gleam
@@ -9,5 +9,5 @@ pub fn main() {
 
   echo teacher.name
   echo student.name
-  // echo teacher.subject
+  // echo student.subject
 }


### PR DESCRIPTION
The content says "Uncomment the `student.subject` line to see the compile error from trying to use this accessor."