### PR TITLE
Document `as` keyword with `let assert`

### DIFF
--- a/src/content/chapter5_advanced_features/lesson05_let_assert/code.gleam
+++ b/src/content/chapter5_advanced_features/lesson05_let_assert/code.gleam
@@ -9,6 +9,6 @@ pub fn main() {
 pub fn unsafely_get_first_element(items: List(a)) -> a {
   // This will panic if the list is empty.
   // A regular `let` would not permit this partial pattern
-  let assert [first, ..] = items
+  let assert [first, ..] = items as "List should not be empty"
   first
 }

--- a/src/content/chapter5_advanced_features/lesson05_let_assert/en.html
+++ b/src/content/chapter5_advanced_features/lesson05_let_assert/en.html
@@ -10,6 +10,11 @@
   type being assigned.
 </p>
 <p>
+  Just like <code>panic</code> and <code>todo</code>, the <code>as</code> keyword
+  can be used with <code>let assert</code> to supply a custom panic message if
+  the pattern fails to match and the program crashes.
+</p>
+<p>
   Like <code>panic</code> this feature should be used sparingly, and likely not
   at all in libraries.
 </p>


### PR DESCRIPTION
I noticed that we were missing documentation about the `let assert ... as` construct, so this PR adds it.