### PR TITLE
Fix grammar on Tail calls page

### DIFF
--- a/src/content/chapter2_flow_control/lesson06_tail_calls/en.html
+++ b/src/content/chapter2_flow_control/lesson06_tail_calls/en.html
@@ -17,7 +17,7 @@
   language with <code>while</code> loops.
 </p>
 <p>
-  Accumulators should be hidden away from the users of your code, they are
+  Accumulators should be hidden away from the users of your code; they are
   internal implementation details. To do this write a public function that calls
   a recursive private function with the initial accumulator value.
 </p>


### PR DESCRIPTION
These are two complete sentences, so we can't join them with a comma. It has to be either a period, a semicolon, or a dash. I felt like a semicolon best matched the tone.