### PR TITLE
Fix missing syntax highlighting on load

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -99,4 +99,15 @@ worker.onmessage = (event) => {
   queuedWork = undefined;
 };
 
-editor.onUpdate(debounce((code) => sendToWorker(code), 200));
+// On the first update, the syntax highlighting is broken, so we use a flag
+// to manually call the highlight() method on the editor the first time
+let shouldManuallyHighlight = true;
+editor.onUpdate(
+  debounce((code) => {
+    sendToWorker(code);
+    if (shouldManuallyHighlight) {
+      editor.highlight();
+      shouldManuallyHighlight = false;
+    }
+  }, 200),
+);


### PR DESCRIPTION
When the interactive code editor first loads, there is a flash of syntax highlighting which then disappears. I'm not sure why this happens, but manually calling the `highlight()` method on the editor the first time the `onUpdate` callback runs fixes the problem.