### PR TITLE
Fix typo in lesson01_use

### DIFF
--- a/src/content/chapter5_advanced_features/lesson01_use/en.html
+++ b/src/content/chapter5_advanced_features/lesson01_use/en.html
@@ -5,7 +5,7 @@
   sometimes result in excessive indentation.
 </p>
 <p>
-  Gleam's <code>use</code> expression for calling functions that take a
+  Gleam's <code>use</code> expression is for calling functions that take a
   callback as an argument without increasing the indentation of the code.
 </p>
 


### PR DESCRIPTION
One word fix to a sentence in the lesson on the `use` expression.