### PR TITLE
Another echo dict as list to avoid wasm echo format bug

### DIFF
--- a/src/content/chapter4_standard_library/lesson03_dict_module/code.gleam
+++ b/src/content/chapter4_standard_library/lesson03_dict_module/code.gleam
@@ -2,7 +2,7 @@ import gleam/dict
 
 pub fn main() {
   let scores = dict.from_list([#("Lucy", 13), #("Drew", 15)])
-  echo scores
+  echo dict.to_list(scores)
 
   let scores =
     scores


### PR DESCRIPTION
One of the `echo` statements was missed when using `dict.to_list` workaround for echo bug. 